### PR TITLE
refactor: update to latest vuepress usage

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -1,5 +1,4 @@
-// .vuepress/client.ts
-import { defineClientConfig } from "@vuepress/client";
+import { defineClientConfig } from "vuepress/client";
 import NaiveClient from "./components/NaiveClient.vue";
 
 export default defineClientConfig({

--- a/docs/.vuepress/components/HomeAds.vue
+++ b/docs/.vuepress/components/HomeAds.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { usePageData } from "@vuepress/client"
+import { usePageData } from "vuepress/client"
 import { computed } from "vue"
 
 const pageData = usePageData()

--- a/docs/.vuepress/components/HomePage.vue
+++ b/docs/.vuepress/components/HomePage.vue
@@ -10,6 +10,6 @@
 <script setup lang="ts">
 import HopeHomePage from "vuepress-theme-hope/components/HomePage";
 // import HomeAds from "./HomeAds.vue";
-import { ClientOnly } from "@vuepress/client";
+import { ClientOnly } from "vuepress/client";
 
 </script>

--- a/docs/.vuepress/components/NaiveClient.vue
+++ b/docs/.vuepress/components/NaiveClient.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
-
 import NaiveConfig from './NaiveConfig.vue';
-import { ClientOnly } from '@vuepress/client';
+import { ClientOnly } from 'vuepress/client';
 import { Suspense } from 'vue'
 import { NSpace, NSpin } from 'naive-ui'
 

--- a/docs/.vuepress/components/NormalPage.vue
+++ b/docs/.vuepress/components/NormalPage.vue
@@ -10,9 +10,9 @@
 </template>
 <script setup lang="ts">
 import NormalPage from "vuepress-theme-hope/components/NormalPage";
-import { usePageFrontmatter } from "@vuepress/client";
+import { usePageFrontmatter } from "vuepress/client";
 import { computed } from "vue";
-import { usePageData } from '@vuepress/client'
+import { usePageData } from 'vuepress/client'
 import NaiveClient from './NaiveClient.vue'
 import ApiSelect from "./api/ApiSelect.vue";
 

--- a/docs/.vuepress/components/Sidebar.vue
+++ b/docs/.vuepress/components/Sidebar.vue
@@ -19,7 +19,7 @@
 </template>
 <script setup lang="ts">
 import Sidebar from "vuepress-theme-hope/modules/sidebar/components/Sidebar";
-import { usePageData } from "@vuepress/client";
+import { usePageData } from "vuepress/client";
 import { computed } from "vue";
 import ApiSelect from "./api/ApiSelect.vue";
 

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -1,6 +1,6 @@
 import { defineUserConfig } from "vuepress";
 import { viteBundler } from '@vuepress/bundler-vite'
-import { getDirname, path } from "@vuepress/utils";
+import { getDirname, path } from "vuepress/utils";
 import theme from "./theme.js";
 
 const __dirname = getDirname(import.meta.url);

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,0 +1,3 @@
+h1 .vp-icon {
+  font-size: 1em;
+}

--- a/docs/.vuepress/theme.ts
+++ b/docs/.vuepress/theme.ts
@@ -8,13 +8,6 @@ export default hopeTheme(
     logo: "/logo.svg",
     repo: "OpenListTeam/docs",
     // hostname: "https://docs.oplist.org",
-    // 移动到 palette.scss 文件中
-    // themeColor: {
-    //   blue: "#2196f3",
-    //   red: "#f26d6d",
-    //   green: "#3eaf7c",
-    //   orange: "#fb9b5f",
-    // },
 
     author: {
       name: "The OpenList Projects Contributors",
@@ -25,14 +18,9 @@ export default hopeTheme(
 
     locales: {
       "/": {
-        // navbar
         navbar: navbar.en,
-
-        // sidebar
         sidebar: sidebar.en,
-
-        footer: ``,
-
+        footer: '',
         displayFooter: true,
       },
 
@@ -40,42 +28,27 @@ export default hopeTheme(
        * Chinese locale config
        */
       "/zh/": {
-        // navbar
         navbar: navbar.zh,
-
-        // sidebar
         sidebar: sidebar.zh,
-
-        footer: ``,
-
+        footer: '',
         displayFooter: true,
       },
     },
     markdown: {
-      imgMark: true,      //支持图片标记
-      imgLazyload: true,  //支持图片懒加载
-      // figure: true,       //支持图片描述
-      imgSize: true,      //支持图片大小
-      tabs: true,         //支持表格
-      gfm: true,          //支持完整的 GFM 语法
-      tasklist: true,     //支持任务列表
-      include: true,      //支持 include 语法
-      align: true,        //支持对齐
-      mark: true,         //支持标记
-      sub: true,          //支持下标
-      sup: true,          //支持上标
-      flowchart: true,    //支持流程图
-      demo: true,         //支持 demo
-      mermaid: true,      //支持 Mermaid
-      chartjs: true,      //支持 Chart.js
-      echarts: true,      //支持 ECharts
-      plantuml: true,     //支持 PlantUML
-      codeTabs: true,     //支持代码块分组
-      // container: true,
+      imgMark: true,
+      imgLazyload: true,
+      tabs: true,
+      gfm: true,
+      tasklist: true,
+      include: true,
+      mark: true,
+      sub: true,
+      sup: true,
+      flowchart: true,
+      mermaid: true,
+      codeTabs: true,
     },
     plugins: {
-      // 水印选项 
-      // 参考配置：https://zhensherlock.github.io/watermark-js-plus/zh/config
       watermark:{
         enabled: false,
       },
@@ -92,11 +65,9 @@ export default hopeTheme(
           toc: false,
         }),
       },
-      // 
       components: {
         components: ["ArtPlayer", "BiliBili", "Badge", "VPCard"],
       },
-      // 图标
       icon: {
         assets: [
           "//at.alicdn.com/t/c/font_2410206_5vb9zlyghj.css",
@@ -105,9 +76,6 @@ export default hopeTheme(
         ]
       },
       comment: {
-        /**
-         * Using Giscus 评论
-         */
         provider: "Giscus",
         repo: "OpenListTeam/docs",
         repoId: "R_kgDOO52WYA",
@@ -166,9 +134,6 @@ export default hopeTheme(
     },
   },
   {
-    check: true,
-    compact: true,
     custom: true,
-    debug: false,
   }
 );

--- a/package.json
+++ b/package.json
@@ -18,15 +18,13 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.75",
-    "@vuepress/client": "2.0.0-rc.19",
+    "@vuepress/bundler-vite": "2.0.0-rc.19",
     "@vuepress/plugin-docsearch": "2.0.0-rc.74",
-    "@vuepress/utils": "2.0.0-rc.19",
     "artplayer": "^5.2.2",
-    "chart.js": "^4.4.7",
     "dashjs": "^4.7.4",
-    "echarts": "^5.6.0",
     "flowchart.ts": "^3.0.1",
     "hls.js": "^1.5.20",
+    "markdown-it": "^14.1.0",
     "mathjax-full": "^3.2.2",
     "mermaid": "^11.4.1",
     "mpegts.js": "^1.8.0",
@@ -35,9 +33,5 @@
     "vue": "^3.5.13",
     "vuepress": "2.0.0-rc.19",
     "vuepress-theme-hope": "2.0.0-rc.71"
-  },
-  "dependencies": {
-    "@vuepress/bundler-vite": "2.0.0-rc.19",
-    "markdown-it": "^14.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,44 +7,31 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@vuepress/bundler-vite':
-        specifier: 2.0.0-rc.19
-        version: 2.0.0-rc.19(@types/node@18.19.75)(sass@1.84.0)(yaml@2.7.0)
-      markdown-it:
-        specifier: ^14.1.0
-        version: 14.1.0
     devDependencies:
       '@types/node':
         specifier: ^18.19.75
         version: 18.19.75
-      '@vuepress/client':
+      '@vuepress/bundler-vite':
         specifier: 2.0.0-rc.19
-        version: 2.0.0-rc.19
+        version: 2.0.0-rc.19(@types/node@18.19.75)(sass@1.84.0)(yaml@2.7.0)
       '@vuepress/plugin-docsearch':
         specifier: 2.0.0-rc.74
         version: 2.0.0-rc.74(@algolia/client-search@5.20.1)(search-insights@2.11.0)(vuepress@2.0.0-rc.19(@vuepress/bundler-vite@2.0.0-rc.19(@types/node@18.19.75)(sass@1.84.0)(yaml@2.7.0))(vue@3.5.13))
-      '@vuepress/utils':
-        specifier: 2.0.0-rc.19
-        version: 2.0.0-rc.19
       artplayer:
         specifier: ^5.2.2
         version: 5.2.2
-      chart.js:
-        specifier: ^4.4.7
-        version: 4.4.7
       dashjs:
         specifier: ^4.7.4
         version: 4.7.4
-      echarts:
-        specifier: ^5.6.0
-        version: 5.6.0
       flowchart.ts:
         specifier: ^3.0.1
         version: 3.0.1
       hls.js:
         specifier: ^1.5.20
         version: 1.5.20
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
       mathjax-full:
         specifier: ^3.2.2
         version: 3.2.2
@@ -820,42 +807,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -917,61 +898,51 @@ packages:
     resolution: {integrity: sha512-6jyiXKF9Xq6x9yQjct5xrRT0VghJk5VzAfed3o0hgncwacZkzOdR0TXLRNjexsEXWN8tG7jWWwsVk7WeFi//gw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.5':
     resolution: {integrity: sha512-cOTYe5tLcGAvGztRLIqx87LE7j/qjaAqFrrHsPFlnuhhhFO5LSr2AzvdQYuxomJMzMBrXkMRNl9bQEpDZ5bjLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.5':
     resolution: {integrity: sha512-KHlrd+YqmS7rriW+LBb1kQNYmd5w1sAIG3z7HEpnQOrg/skeYYv9DAcclGL9gpFdpnzmiAEkzsTT74kZWUtChQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.5':
     resolution: {integrity: sha512-uOb6hzDqym4Sw+qw3+svS3SmwQGVUhyTdPKyHDdlYg1Z0aHjdNmjwRY7zw/90/UfBe/yD7Mv2mYKhQpOfy4RYA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.5':
     resolution: {integrity: sha512-pARu8ZKANZH4wINLdHLKG69EPwJswM6A+Ox1a9LpiclRQoyjacFFTtXN3akKQ2ufJXDasO/pWvxKN9ZfCgEoFA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.5':
     resolution: {integrity: sha512-crUWn12NRmCdao2YwS1GvlPCVypMBMJlexTaantaP2+dAMd2eZBErFcKG8hZYEHjSbbk2UoH1aTlyeA4iKLqSA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.5':
     resolution: {integrity: sha512-XtD/oMhCdixi3x8rCNyDRMUsLo1Z+1UQcK+oR7AsjglGov9ETiT3TNFhUPzaGC1jH+uaMtPhxrVRUub+pnAKTg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.5':
     resolution: {integrity: sha512-V3+BvgyHb21aF7lw0sc78Tv0+xLp4lm2OM7CKFVrBuppsMvtl/9O5y2OX4tdDT0EhIsDP/ObJPqDuEg1ZoTwSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.5':
     resolution: {integrity: sha512-SkCIXLGk42yldTcH8UXh++m0snVxp9DLf4meb1mWm0lC8jzxjFBwSLGtUSeLgQDsC05iBaIhyjNX46DlByrApQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.5':
     resolution: {integrity: sha512-iUcH3FBtBN2/Ce0rI84suRhD0+bB5BVEffqOwsGaX5py5TuYLOQa7S7oVBP0NKtB5rub3i9IvZtMXiD96l5v0A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.5':
     resolution: {integrity: sha512-PUbWd+h/h6rUowalDYIdc9S9LJXbQDMcJe0BjABl3oT3efYRgZ8aUe8ZZDSie7y+fz6Z+rueNfdorIbkWv5Eqg==}
@@ -3377,7 +3348,8 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@kurkle/color@0.3.4': {}
+  '@kurkle/color@0.3.4':
+    optional: true
 
   '@lit-labs/ssr-dom-shim@1.3.0': {}
 
@@ -4610,6 +4582,7 @@ snapshots:
   chart.js@4.4.7:
     dependencies:
       '@kurkle/color': 0.3.4
+    optional: true
 
   cheerio-select@2.1.0:
     dependencies:
@@ -4989,6 +4962,7 @@ snapshots:
     dependencies:
       tslib: 2.3.0
       zrender: 5.6.1
+    optional: true
 
   electron-to-chromium@1.5.96: {}
 
@@ -5838,7 +5812,8 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  tslib@2.3.0: {}
+  tslib@2.3.0:
+    optional: true
 
   tslib@2.8.1: {}
 
@@ -6158,5 +6133,6 @@ snapshots:
   zrender@5.6.1:
     dependencies:
       tslib: 2.3.0
+    optional: true
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
（#29 #30 由于 `openlist-migration` 分支被删掉了所以自动关了）